### PR TITLE
Add drag-and-drop and image mode support

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,10 +9,13 @@ from PIL import Image
 import os
 import sys
 import threading
-import webbrowser  # <--- Added for GitHub link
-import subprocess  # <--- Added for opening files on non-Windows systems
+import webbrowser
+import subprocess
 import customtkinter as ctk
 from tkinter import filedialog, messagebox
+
+# --- NEW IMPORT FOR DRAG AND DROP ---
+from tkinterdnd2 import TkinterDnD, DND_FILES
 
 # --- CONFIGURATION ---
 ctk.set_appearance_mode("Dark")
@@ -22,11 +25,9 @@ ctk.set_default_color_theme("blue")
 def resource_path(relative_path):
     """ Get absolute path to resource, works for dev and for PyInstaller """
     try:
-        # PyInstaller creates a temp folder and stores path in _MEIPASS
         base_path = sys._MEIPASS
     except Exception:
         base_path = os.path.abspath(".")
-
     return os.path.join(base_path, relative_path)
 
 # --- Geometry & Cropping Helpers ---
@@ -58,11 +59,11 @@ def four_point_transform(image, pts):
     return cv2.warpPerspective(image, M, (maxWidth, maxHeight))
 
 def process_single_page(image):
-    # Resize for processing speed
+    # image is BGR numpy array
     orig_h, orig_w = image.shape[:2]
     ratio = 800.0 / orig_h
     small_img = cv2.resize(image, (int(orig_w * ratio), 800))
-    
+
     # Edge Detection
     hsv = cv2.cvtColor(small_img, cv2.COLOR_BGR2HSV)
     lower_white = np.array([0, 0, 100])
@@ -71,40 +72,63 @@ def process_single_page(image):
     kernel = np.ones((5,5), np.uint8)
     mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
     mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
-    
+
     # Contours
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     contours = sorted(contours, key=cv2.contourArea, reverse=True)[:1]
     screenCnt = None
-    
+
     if contours:
         c = contours[0]
         peri = cv2.arcLength(c, True)
         approx = cv2.approxPolyDP(c, 0.02 * peri, True)
         if len(approx) == 4 and cv2.contourArea(approx) > (0.15 * (800 * int(orig_w * ratio))):
             screenCnt = approx
-            
+
     # Transform
     if screenCnt is not None:
         screenCnt = screenCnt.reshape(4, 2) * (1.0 / ratio)
         warped = four_point_transform(image, screenCnt)
     else:
         warped = image
-        
+
     # Thresholding
     gray = cv2.cvtColor(warped, cv2.COLOR_BGR2GRAY)
     binary = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 21, 10)
     denoised = cv2.medianBlur(binary, 3)
     return denoised
 
+def load_image_to_bgr(path):
+    """Load an image file and convert to BGR format (OpenCV compatible)."""
+    pil_img = Image.open(path)
+    if pil_img.mode == 'RGBA':
+        # Convert to RGB first (discard alpha)
+        rgb_img = Image.new('RGB', pil_img.size, (255, 255, 255))
+        rgb_img.paste(pil_img, mask=pil_img.split()[3])  # Paste using alpha as mask
+        bgr_img = cv2.cvtColor(np.array(rgb_img), cv2.COLOR_RGB2BGR)
+    elif pil_img.mode != 'RGB':
+        pil_img = pil_img.convert('RGB')
+        bgr_img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+    else:
+        bgr_img = cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+    return bgr_img
+
 # --- GUI Logic ---
-class ScannerApp(ctk.CTk):
+# Inherit from TkinterDnD.DnDWrapper to enable drag and drop in CTk
+class ScannerApp(ctk.CTk, TkinterDnD.DnDWrapper):
     def __init__(self):
         super().__init__()
 
-        # Window Setup
+        # --- Initialize Drag and Drop ---
+        try:
+            self.TkdndVersion = TkinterDnD._require(self)
+            self.drop_target_register(DND_FILES)
+            self.dnd_bind('<<Drop>>', self.handle_drop)
+        except Exception as e:
+            print(f"Warning: Drag and Drop functionality could not be loaded: {e}")
+
         self.title("PDF Enhancer")
-        self.geometry("600x450") # Increased height slightly for the footer
+        self.geometry("600x500")  # Increased height for mode selector
         self.resizable(False, False)
 
         # SET ICON
@@ -112,38 +136,49 @@ class ScannerApp(ctk.CTk):
             icon_path = resource_path("scanner.ico")
             self.iconbitmap(icon_path)
         except Exception:
-            pass  # Icon not found, use default
+            pass
 
         # Layout Grid
         self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(0, weight=0) # Title
-        self.grid_rowconfigure(1, weight=0) # Input
-        self.grid_rowconfigure(2, weight=0) # Settings
-        self.grid_rowconfigure(3, weight=0) # Buttons
-        self.grid_rowconfigure(4, weight=1) # Status
-        self.grid_rowconfigure(5, weight=0) # GitHub Footer (NEW)
+        self.grid_rowconfigure(0, weight=0)  # Title
+        self.grid_rowconfigure(1, weight=0)  # Input
+        self.grid_rowconfigure(2, weight=0)  # Settings + Mode
+        self.grid_rowconfigure(3, weight=0)  # Buttons
+        self.grid_rowconfigure(4, weight=1)  # Status
+        self.grid_rowconfigure(5, weight=0)  # GitHub Footer
 
         # 1. Header
         self.lbl_title = ctk.CTkLabel(self, text="📄 PDF Clean Scanner", font=ctk.CTkFont(size=24, weight="bold"))
         self.lbl_title.grid(row=0, column=0, padx=20, pady=(20, 10))
 
-        # 2. File Selection
+        # 2. File Selection Frame
         self.frame_file = ctk.CTkFrame(self)
         self.frame_file.grid(row=1, column=0, padx=20, pady=10, sticky="ew")
-        
-        self.lbl_file_path = ctk.CTkLabel(self.frame_file, text="No PDF selected", text_color="gray")
+
+        # Updated default text to indicate DnD is available
+        self.lbl_file_path = ctk.CTkLabel(self.frame_file, text="Drag & drop files here or browse", text_color="gray")
         self.lbl_file_path.pack(side="left", padx=15, pady=15)
-        
-        self.btn_browse = ctk.CTkButton(self.frame_file, text="Browse PDF", command=self.browse_file)
+
+        self.btn_browse = ctk.CTkButton(self.frame_file, text="Browse", command=self.browse_file)
         self.btn_browse.pack(side="right", padx=15, pady=15)
 
-        # 3. Settings
+        # 3. Settings Frame (includes DPI and Mode)
         self.frame_settings = ctk.CTkFrame(self)
         self.frame_settings.grid(row=2, column=0, padx=20, pady=10, sticky="ew")
 
+        # Mode selector
+        self.mode_var = ctk.StringVar(value="pdf")
+        self.mode_selector = ctk.CTkSegmentedButton(
+            self.frame_settings,
+            values=["PDF", "Images"],
+            variable=self.mode_var,
+            command=self.mode_changed
+        )
+        self.mode_selector.pack(side="top", pady=(10, 5))
+
         self.lbl_dpi = ctk.CTkLabel(self.frame_settings, text="Scan Quality (DPI): 200")
-        self.lbl_dpi.pack(side="top", pady=(10, 0))
-        
+        self.lbl_dpi.pack(side="top", pady=(5, 0))
+
         self.slider_dpi = ctk.CTkSlider(self.frame_settings, from_=100, to=400, number_of_steps=6, command=self.update_dpi_label)
         self.slider_dpi.set(200)
         self.slider_dpi.pack(side="top", fill="x", padx=20, pady=(5, 15))
@@ -151,24 +186,31 @@ class ScannerApp(ctk.CTk):
         # 4. Buttons
         self.frame_buttons = ctk.CTkFrame(self, fg_color="transparent")
         self.frame_buttons.grid(row=3, column=0, padx=20, pady=20, sticky="ew")
-        
-        self.btn_preview = ctk.CTkButton(self.frame_buttons, text="👁 Preview First Page", command=self.open_preview_window, height=50, fg_color="#E67E22", hover_color="#D35400", font=ctk.CTkFont(size=16, weight="bold"))
+
+        self.btn_preview = ctk.CTkButton(
+            self.frame_buttons, text="👁 Preview First", command=self.open_preview_window,
+            height=50, fg_color="#E67E22", hover_color="#D35400",
+            font=ctk.CTkFont(size=16, weight="bold")
+        )
         self.btn_preview.pack(side="left", expand=True, fill="x", padx=(0, 10))
 
-        self.btn_convert = ctk.CTkButton(self.frame_buttons, text="💾 Convert & Save", command=self.start_conversion_thread, height=50, font=ctk.CTkFont(size=16, weight="bold"))
+        self.btn_convert = ctk.CTkButton(
+            self.frame_buttons, text="💾 Convert & Save", command=self.start_conversion_thread,
+            height=50, font=ctk.CTkFont(size=16, weight="bold")
+        )
         self.btn_convert.pack(side="right", expand=True, fill="x", padx=(10, 0))
 
         # 5. Status
         self.lbl_status = ctk.CTkLabel(self, text="Ready", text_color="gray")
         self.lbl_status.grid(row=4, column=0, padx=20, pady=(0, 5), sticky="s")
 
-        # 6. GitHub Footer (NEW)
+        # 6. GitHub Footer
         self.btn_github = ctk.CTkButton(
-            self, 
-            text="Developed by @ItsSp00ky | GitHub", 
+            self,
+            text="Developed by @ItsSp00ky | GitHub",
             command=self.open_github,
             fg_color="transparent",
-            text_color=("#3B8ED0", "#1F6AA5"), # Link blue
+            text_color=("#3B8ED0", "#1F6AA5"),
             hover_color=("gray90", "gray20"),
             height=20,
             font=ctk.CTkFont(size=11, underline=True)
@@ -176,13 +218,11 @@ class ScannerApp(ctk.CTk):
         self.btn_github.grid(row=5, column=0, pady=(0, 10))
 
         # Application State
-        self.selected_file = None
-        
-        # Preview State
+        self.input_files = []          # list of file paths (one for PDF, multiple for images)
         self.preview_window = None
-        self.preview_doc = None
+        self.preview_doc = None        # only used for PDF preview
         self.preview_img_label = None
-        self.current_preview_image = None 
+        self.current_preview_image = None
 
     def open_github(self):
         webbrowser.open("https://github.com/ItsSp00ky/pdf_enhancer")
@@ -190,37 +230,102 @@ class ScannerApp(ctk.CTk):
     def update_dpi_label(self, value):
         self.lbl_dpi.configure(text=f"Scan Quality (DPI): {int(value)}")
 
-    def browse_file(self):
-        filename = filedialog.askopenfilename(filetypes=[("PDF Files", "*.pdf")])
-        if filename:
-            self.selected_file = filename
-            self.lbl_file_path.configure(text=os.path.basename(filename), text_color=("black", "white"))
-            self.lbl_status.configure(text="File loaded. Ready.", text_color="green")
+    def mode_changed(self, value):
+        """Called when the mode selector changes."""
+        self.input_files = []
+        self.lbl_file_path.configure(text="Drag & drop files here or browse", text_color="gray")
+        # Update browse button text based on mode
+        if value == "PDF":
+            self.btn_browse.configure(text="Browse PDF")
+        else:
+            self.btn_browse.configure(text="Browse Images")
 
-    # --- PREVIEW LOGIC (SINGLE PAGE ONLY) ---
-    def open_preview_window(self):
-        if not self.selected_file:
-            messagebox.showwarning("Warning", "Please select a PDF file first!")
-            return
+    # --- DRAG AND DROP HANDLER ---
+    def handle_drop(self, event):
+        """Handles files dropped into the application window."""
+        # Safely split paths (handles spaces and curly braces natively via Tkinter)
+        dropped_files = self.tk.splitlist(event.data)
+        mode = self.mode_var.get()
+        valid_files = []
+
+        if mode == "PDF":
+            # Find the first PDF in the dropped items
+            for f in dropped_files:
+                if f.lower().endswith(".pdf"):
+                    valid_files.append(f)
+                    break
+                    
+            if valid_files:
+                self.input_files = valid_files
+                self.lbl_file_path.configure(text=os.path.basename(valid_files[0]), text_color=("black", "white"))
+                self.lbl_status.configure(text="PDF loaded via Drag & Drop. Ready.", text_color="green")
+            else:
+                messagebox.showwarning("Invalid File", "Please drop a valid PDF file.")
+
+        else:  # Images Mode
+            valid_exts = ('.jpg', '.jpeg', '.png', '.bmp', '.tiff')
+            for f in dropped_files:
+                if f.lower().endswith(valid_exts):
+                    valid_files.append(f)
             
+            if valid_files:
+                self.input_files = valid_files
+                if len(valid_files) == 1:
+                    display_text = os.path.basename(valid_files[0])
+                else:
+                    display_text = f"{len(valid_files)} images loaded"
+                
+                self.lbl_file_path.configure(text=display_text, text_color=("black", "white"))
+                self.lbl_status.configure(text="Images loaded via Drag & Drop. Ready.", text_color="green")
+            else:
+                messagebox.showwarning("Invalid File", "Please drop valid image files (JPG, PNG, BMP, TIFF).")
+
+
+    def browse_file(self):
+        mode = self.mode_var.get()
+        if mode == "PDF":
+            filename = filedialog.askopenfilename(filetypes=[("PDF Files", "*.pdf")])
+            if filename:
+                self.input_files = [filename]
+                self.lbl_file_path.configure(text=os.path.basename(filename), text_color=("black", "white"))
+                self.lbl_status.configure(text="File loaded. Ready.", text_color="green")
+        else:  # Images mode
+            filenames = filedialog.askopenfilenames(
+                filetypes=[("Image Files", "*.jpg *.jpeg *.png *.bmp *.tiff")]
+            )
+            if filenames:
+                self.input_files = list(filenames)
+                if len(filenames) == 1:
+                    display_text = os.path.basename(filenames[0])
+                else:
+                    display_text = f"{len(filenames)} images selected"
+                self.lbl_file_path.configure(text=display_text, text_color=("black", "white"))
+                self.lbl_status.configure(text="Images loaded. Ready.", text_color="green")
+
+    # --- PREVIEW LOGIC (First file only) ---
+    def open_preview_window(self):
+        if not self.input_files:
+            messagebox.showwarning("Warning", "Please select or drop a file first!")
+            return
+
+        mode = self.mode_var.get()
         try:
-            self.preview_doc = fitz.open(self.selected_file)
-            if len(self.preview_doc) < 1:
-                messagebox.showerror("Error", "PDF is empty.")
-                return
+            if mode == "PDF":
+                self.preview_doc = fitz.open(self.input_files[0])
+                if len(self.preview_doc) < 1:
+                    messagebox.showerror("Error", "PDF is empty.")
+                    return
+            # For images, no document to keep open; we'll load on the fly
         except Exception as e:
-            messagebox.showerror("Error", f"Could not open PDF: {e}")
+            messagebox.showerror("Error", f"Could not open file: {e}")
             return
 
         if self.preview_window is None or not self.preview_window.winfo_exists():
             self.preview_window = ctk.CTkToplevel(self)
-            self.preview_window.title("First Page Preview")
+            self.preview_window.title("First Item Preview")
             self.preview_window.geometry("600x700")
-            
-            # --- MAKE WINDOW APPEAR ON TOP ---
             self.preview_window.attributes("-topmost", True)
-            
-            # --- SET ICON FOR PREVIEW ---
+
             try:
                 icon_path = resource_path("scanner.ico")
                 self.preview_window.iconbitmap(icon_path)
@@ -228,124 +333,133 @@ class ScannerApp(ctk.CTk):
                 pass
 
             self.preview_window.protocol("WM_DELETE_WINDOW", self.close_preview_window)
-            
-            # Title
-            lbl_info = ctk.CTkLabel(self.preview_window, text="Previewing First Page Only", font=("Arial", 14, "bold"))
+
+            lbl_info = ctk.CTkLabel(self.preview_window, text="Previewing First Item Only", font=("Arial", 14, "bold"))
             lbl_info.pack(pady=10)
 
-            # Image Area
-            self.preview_img_label = ctk.CTkLabel(self.preview_window, text="Processing...", width=500, height=600, corner_radius=10, fg_color="#2B2B2B")
+            self.preview_img_label = ctk.CTkLabel(
+                self.preview_window, text="Processing...", width=500, height=600,
+                corner_radius=10, fg_color="#2B2B2B"
+            )
             self.preview_img_label.pack(padx=20, pady=(0, 20), expand=True, fill="both")
-        
+
         self.preview_window.focus()
-        
-        # Start processing thread for Page 0
         threading.Thread(target=self.process_preview_thread, daemon=True).start()
 
     def close_preview_window(self):
         if self.preview_doc:
             self.preview_doc.close()
             self.preview_doc = None
-        self.preview_window.destroy()
+        if self.preview_window:
+            self.preview_window.destroy()
 
     def process_preview_thread(self):
         try:
-            # Always load page 0
-            page = self.preview_doc[0]
+            mode = self.mode_var.get()
             dpi_val = int(self.slider_dpi.get())
-            pix = page.get_pixmap(dpi=dpi_val)
-            
-            img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width, pix.n)
-            if pix.n == 4:
-                img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
-            elif pix.n == 3:
-                img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+
+            if mode == "PDF":
+                page = self.preview_doc[0]
+                pix = page.get_pixmap(dpi=dpi_val)
+                img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width, pix.n)
+                if pix.n == 4:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+                elif pix.n == 3:
+                    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+            else:  # Images
+                # Load first image
+                img = load_image_to_bgr(self.input_files[0])
 
             enhanced = process_single_page(img)
             pil_img = Image.fromarray(enhanced)
-            
-            # Pass result to UI thread
             self.after(0, lambda: self.update_preview_ui(pil_img))
-            
+
         except Exception as e:
             print(f"Preview Error: {e}")
-            self.after(0, lambda: self.preview_img_label.configure(text="Error loading page.", image=None))
+            self.after(0, lambda: self.preview_img_label.configure(text="Error loading preview.", image=None))
 
     def update_preview_ui(self, pil_img):
-        # Check if window was closed during processing
         if not self.preview_window or not self.preview_window.winfo_exists():
             return
 
-        # 1. Calculate Dimensions
         w, h = pil_img.size
         aspect = h / w
         display_w = 500
         display_h = int(display_w * aspect)
-        
         if display_h > 600:
             display_h = 600
             display_w = int(display_h / aspect)
 
-        # 2. Create CTkImage
-        # Creating CTkImage on the main thread (here) prevents the TclError
         self.current_preview_image = ctk.CTkImage(
             light_image=pil_img,
             dark_image=pil_img,
             size=(display_w, display_h)
         )
-
-        # 3. Update Label
         self.preview_img_label.configure(image=self.current_preview_image, text="")
 
     # --- CONVERSION LOGIC ---
     def start_conversion_thread(self):
-        if not self.selected_file:
-            messagebox.showwarning("Warning", "Please select a PDF file first!")
+        if not self.input_files:
+            messagebox.showwarning("Warning", "Please select or drop a file first!")
             return
+
+        # Suggest output filename based on first input file
+        base = os.path.splitext(os.path.basename(self.input_files[0]))[0]
+        suggested = f"{base}_scanned.pdf"
 
         save_path = filedialog.asksaveasfilename(
             defaultextension=".pdf",
             filetypes=[("PDF Files", "*.pdf")],
-            initialfile=os.path.splitext(os.path.basename(self.selected_file))[0] + "_scanned.pdf",
+            initialfile=suggested,
             title="Save Scanned PDF As"
         )
 
         if not save_path:
-            return 
+            return
 
         self.btn_convert.configure(state="disabled", text="Processing...")
         self.btn_preview.configure(state="disabled")
         self.btn_browse.configure(state="disabled")
-        
+
         threading.Thread(target=self.run_pipeline, args=(save_path,), daemon=True).start()
 
     def run_pipeline(self, output_path):
         try:
-            doc = fitz.open(self.selected_file)
             processed_pages = []
             dpi_val = int(self.slider_dpi.get())
-            total_pages = len(doc)
+            mode = self.mode_var.get()
 
-            for i, page in enumerate(doc):
-                self.after(0, lambda p=i+1, t=total_pages: self.lbl_status.configure(text=f"Scanning Page {p} of {t}...", text_color="orange"))
-                
-                pix = page.get_pixmap(dpi=dpi_val)
-                img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width, pix.n)
-                
-                if pix.n == 4:
-                    img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
-                elif pix.n == 3:
-                    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
-                
-                enhanced = process_single_page(img)
-                pil_img = Image.fromarray(enhanced)
-                processed_pages.append(pil_img)
+            if mode == "PDF":
+                doc = fitz.open(self.input_files[0])
+                total_pages = len(doc)
+                for i, page in enumerate(doc):
+                    self.after(0, lambda p=i+1, t=total_pages: self.lbl_status.configure(
+                        text=f"Scanning Page {p} of {t}...", text_color="orange"))
+                    pix = page.get_pixmap(dpi=dpi_val)
+                    img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width, pix.n)
+                    if pix.n == 4:
+                        img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+                    elif pix.n == 3:
+                        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+                    enhanced = process_single_page(img)
+                    pil_img = Image.fromarray(enhanced)
+                    processed_pages.append(pil_img)
+                doc.close()
+            else:  # Images
+                total = len(self.input_files)
+                for idx, img_path in enumerate(self.input_files):
+                    self.after(0, lambda p=idx+1, t=total: self.lbl_status.configure(
+                        text=f"Processing Image {p} of {t}...", text_color="orange"))
+                    img = load_image_to_bgr(img_path)
+                    enhanced = process_single_page(img)
+                    pil_img = Image.fromarray(enhanced)
+                    processed_pages.append(pil_img)
 
             if processed_pages:
                 processed_pages[0].save(output_path, save_all=True, append_images=processed_pages[1:])
                 self.after(0, lambda: self.conversion_success(output_path))
             else:
-                self.after(0, lambda: messagebox.showerror("Error", "No pages found in PDF."))
+                self.after(0, lambda: messagebox.showerror("Error", "No pages/images to process."))
 
         except Exception as e:
             self.after(0, lambda err=str(e): messagebox.showerror("Error", f"An error occurred:\n{err}"))
@@ -354,8 +468,8 @@ class ScannerApp(ctk.CTk):
     def conversion_success(self, path):
         messagebox.showinfo("Success", f"File saved successfully:\n{path}")
         self.lbl_status.configure(text="Conversion Complete!", text_color="green")
-        
-        # --- OPEN FILE LOGIC ---
+
+        # Open the generated PDF
         try:
             if sys.platform == "win32":
                 os.startfile(path)
@@ -365,7 +479,6 @@ class ScannerApp(ctk.CTk):
                 subprocess.call(["xdg-open", path])
         except Exception as e:
             print(f"Error opening file: {e}")
-        # -----------------------
 
         self.reset_ui()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-customtkinter
-pymupdf
-opencv-python-headless
+PyMuPDF
+opencv-python
 numpy
-pillow
-pyinstaller
+Pillow
+customtkinter
+tkinterdnd2


### PR DESCRIPTION
Enable drag-and-drop and add an Images processing mode alongside PDFs. Key changes: import and integrate tkinterdnd2 (DnD wrapper), add mode selector (PDF / Images), implement handle_drop and adjusted browse_file to accept multiple images, add load_image_to_bgr to normalize image loading (RGBA/RGB), extend preview and pipeline to handle both PDF pages and image files, refactor file state to input_files, improve UI text/geometry/labels/buttons and DPI handling, and automatically open the generated PDF after saving. requirements.txt updated to reflect dependency changes (PyMuPDF, opencv-python, Pillow, customtkinter, tkinterdnd2).